### PR TITLE
Fix: artisan commands not working

### DIFF
--- a/src/FormRequestServiceProvider.php
+++ b/src/FormRequestServiceProvider.php
@@ -19,6 +19,7 @@ class FormRequestServiceProvider extends ServiceProvider
         });
 
         $this->app->afterResolving(FormRequest::class, function ($form) {
+            if (!$form instanceof \App\Http\Requests\FormRequest) continue;
             $form->validate();
             $form->resolveUser();
         });


### PR DESCRIPTION
```
Method Illuminate\Http\Request::resolveUser does not exist.
```

When typing any artisan command.